### PR TITLE
Adds offset support for LinearRegressor, LogisticRegressor, LinearCountRegressor

### DIFF
--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -55,9 +55,18 @@ function augment_X(X::Matrix, b::Bool)::Matrix
     return X
 end
 
-
+"""
+When no offset is specied, return X and an empty vector
+"""
 split_X_offset(X, offsetcol::Nothing) = (X, Float64[])
 
+"""
+    split_X_offset(X, offsetcol::Symbol)
+
+Splits the input table X in:
+    - A new table not containing the original offset column
+    - The offset vector extracted from the table
+"""
 function split_X_offset(X, offsetcol::Symbol)
     ct = Tables.columntable(X)
     offset = Tables.getcolumn(ct, offsetcol)

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -13,7 +13,6 @@ module MLJGLMInterface
 # - test Logit, Probit etc on Binomial once binomial case is handled
 # -------------------------------------------------------------------
 
-using Base: offset_if_vec
 export LinearRegressor, LinearBinaryClassifier, LinearCountRegressor
 
 import MLJModelInterface

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ import Distributions
 import StableRNGs
 using Tables
 
+
+expit(X) = 1 ./ (1 .+ exp.(-X))
+
 ###
 ### OLSREGRESSOR
 ###
@@ -45,8 +48,8 @@ model = atom_ols
 @test is_supervised(model)
 @test package_license(model) == "MIT"
 @test prediction_type(model) == :probabilistic
-@test hyperparameters(model) == (:fit_intercept, :allowrankdeficient)
-@test hyperparameter_types(model) == ("Bool", "Bool")
+@test hyperparameters(model) == (:fit_intercept, :allowrankdeficient, :offsetcol)
+@test hyperparameter_types(model) == ("Bool", "Bool", "Union{Nothing, Symbol}")
 
 p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
@@ -97,3 +100,62 @@ fitresult, _, _ = fit(lcr, 1, XTable, y)
 θ̂ = fitted_params(lcr, fitresult).coef
 
 @test norm(θ̂ .- θ)/norm(θ) ≤ 0.03
+
+
+
+@testset "Test offsetting models" begin
+    @testset "Test split_X_offset" begin
+        X = (toto=[1,2,3], tata=[4,5,6])
+        @test MLJGLMInterface.split_X_offset(X, nothing) == (X, Float64[])
+        @test MLJGLMInterface.split_X_offset(X, :toto) == ((tata=[4,5,6],), [1,2,3])
+
+        X = MLJBase.table(rand(rng, N, 3))
+        Xnew, offset = MLJGLMInterface.split_X_offset(X, :x2)
+        @test offset isa Vector
+        @test length(Xnew) == 2
+    end
+
+    # In the following:
+    # The second column is taken as an offset by the model
+    # This is equivalent to assuming the coef is 1 and known 
+    
+    @testset "Test Logistic regression with offset" begin
+        N = 1000
+        rng = StableRNGs.StableRNG(0)
+        X = MLJBase.table(rand(rng, N, 3))
+        y = rand(rng, Distributions.Uniform(0,1), N) .< expit(2*X.x1 + X.x2 - X.x3)
+        y = categorical(y)
+
+        lr = LinearBinaryClassifier(fit_intercept=false, offsetcol=:x2)
+        fitresult, _, report = fit(lr, 1, X, y)
+        fp = fitted_params(lr, fitresult)
+
+        @test fp.coef ≈ [2, -1] atol=0.03
+    end
+    @testset "Test Linear regression with offset" begin
+        N = 1000
+        rng = StableRNGs.StableRNG(0)
+        X = MLJBase.table(rand(rng, N, 3))
+        y = 2*X.x1 + X.x2 - X.x3 + rand(rng, Distributions.Normal(0,1), N) 
+
+        lr = LinearRegressor(fit_intercept=false, offsetcol=:x2)
+        fitresult, _, report = fit(lr, 1, X, y)
+        fp = fitted_params(lr, fitresult)
+
+        @test fp.coef ≈ [2, -1] atol=0.07
+    end
+    @testset "Test Count regression with offset" begin
+        N = 1000
+        rng = StableRNGs.StableRNG(0)
+        X = MLJBase.table(rand(rng, N, 3))
+        y = map(exp.(2*X.x1 + X.x2 - X.x3)) do mu
+            rand(rng, Distributions.Poisson(mu))
+        end
+
+        lcr = LinearCountRegressor(fit_intercept=false, offsetcol=:x2)
+        fitresult, _, _ = fit(lcr, 1, X, y)
+        fp = fitted_params(lcr, fitresult)
+
+        @test fp.coef ≈ [2, -1] atol=0.04
+    end
+end


### PR DESCRIPTION
In the interest of time, I decided to take the short way. Hope this also matches what you had in mind.

I'm wondering to what extent it would be worth implementing the `reformat` method instead of  my `prepare_inputs`? With a return output like `X, y = (Xmatrix, offset), y`? I guess this would mean quite many changes to the tests and code but may be worth for performance? Let me know your thougths.