### PR TITLE
Fix matrix view

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJGLMInterface"
 uuid = "caf8df21-4939-456d-ac9c-5fefbfb04c0c"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -80,6 +80,12 @@ function prepare_inputs(model, X)
     return Xmatrix, offset
 end
 
+
+function prepare_data(model, X, y)
+    Xmatrix, offset = prepare_inputs(model, X)
+    return convert(Vector, y), Xmatrix, offset
+end
+
 """
 glm_report(fitresult)
 
@@ -129,8 +135,8 @@ const GLM_MODELS = Union{<:LinearRegressor, <:LinearBinaryClassifier, <:LinearCo
 
 function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
     # apply the model
-    Xmatrix, offset = prepare_inputs(model, X)
-    fitresult = GLM.glm(Xmatrix, y, Distributions.Normal(), GLM.IdentityLink(); offset=offset)
+    yvec, Xmatrix, offset = prepare_data(model, X, y)
+    fitresult = GLM.glm(Xmatrix, yvec, Distributions.Normal(), GLM.IdentityLink(); offset=offset)
     # form the report
     report    = glm_report(fitresult)
     cache     = nothing
@@ -140,8 +146,8 @@ end
 
 function MMI.fit(model::LinearCountRegressor, verbosity::Int, X, y)
     # apply the model
-    Xmatrix, offset = prepare_inputs(model, X)
-    fitresult = GLM.glm(Xmatrix, y, model.distribution, model.link; offset=offset)
+    yvec, Xmatrix, offset = prepare_data(model, X, y)
+    fitresult = GLM.glm(Xmatrix, yvec, model.distribution, model.link; offset=offset)
     # form the report
     report    = glm_report(fitresult)
     cache     = nothing
@@ -151,9 +157,9 @@ end
 
 function MMI.fit(model::LinearBinaryClassifier, verbosity::Int, X, y)
     # apply the model
-    Xmatrix, offset = prepare_inputs(model, X)
-    decode    = y[1]
-    y_plain   = MMI.int(y) .- 1 # 0, 1 of type Int
+    yvec, Xmatrix, offset = prepare_data(model, X, y)
+    decode    = yvec[1]
+    y_plain   = MMI.int(yvec) .- 1 # 0, 1 of type Int
     fitresult = GLM.glm(Xmatrix, y_plain, Distributions.Bernoulli(), model.link; offset=offset)
     # form the report
     report    = glm_report(fitresult)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
 # Check the machine fit! will work with matrix views
 # Here y is a view from a matrix which is not inherently 
-#supported by GLMs
+# supported by GLMs
 
 mach = machine(atom_ols, X, y)
 fit!(mach)
@@ -114,7 +114,7 @@ modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
     @testset "intercept/offsetcol" for mt in modeltypes
             X = (x1=[1,2,3], x2=[4,5,6])
             m = mt(fit_intercept=true, offsetcol=:x2)
-            Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
+            Xmatrix, offset = MLJGLMInterface.prepare_data_predict(m, X)
 
             @test offset == [4, 5, 6]
             @test Xmatrix== [1 1;
@@ -125,7 +125,7 @@ modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
     @testset "no intercept/no offsetcol" for mt in modeltypes
         X = (x1=[1,2,3], x2=[4,5,6])
         m = mt(fit_intercept=false)
-        Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
+        Xmatrix, offset = MLJGLMInterface.prepare_data_predict(m, X)
 
         @test offset == []
         @test Xmatrix == [1 4;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,13 @@ p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
 @test p_distr[1] == Distributions.Normal(p[1], GLM.dispersion(fitresult))
 
+# Check the machine fit! will work with matrix views
+# Here y is a view from a matrix which is not inherently 
+#supported by GLMs
+
+mach = machine(atom_ols, X, y)
+fit!(mach)
+
 ###
 ### Logistic regression
 ###


### PR DESCRIPTION
The proposed change is:

- Rename `prepare_inputs` to `prepare_data_predict`
- A new `prepare_data_fit` function calling `prepare_data_predict` and converting `y` to a vector.
- `prepare_data_fit` is called by `fit` methods
- `prepare_data_predict` is called by `predict` methods

Converting `y` to be a vector seems to solve  [this issue](https://github.com/JuliaAI/MLJGLMInterface.jl/issues/8) which is in this dispatch:

```julia

function GlmResp(y::V, d::D, l::L, off::V, wts::V) where {V<:FPVector,D,L}
    η   = similar(y)
    μ   = similar(y)
    r   = GlmResp(y, d, l, η, μ, off, wts)
    initialeta!(r.eta, d, l, y, wts, off)
    updateμ!(r, r.eta)
    return r
end

function GlmResp(y::AbstractVector{<:Real}, d::D, l::L, off::AbstractVector{<:Real},
                 wts::AbstractVector{<:Real}) where {D, L}
        GlmResp(float(y), d, l, float(off), float(wts))
end
```

However I don't really understand how it works. The following check will return `true` even when y is a view:

```julia
y isa GLM.FPVector
```
If someone can help me understand that before merging anything?

@edit: Changed functions names in light of Thibaut's remark.