### PR TITLE
Report feature names in `fitresult`

### DIFF
--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -89,18 +89,7 @@ function prepare_inputs(model, X; handle_intercept=false)
 end
 
 """
-    glm_data(model, Xmatrix, X, y)
-
-Return data which is ready to be passed to `fit(form, data, ...)`.
-"""
-function glm_data(model, Xmatrix, X, y)
-    header = collect(filter(x -> x != model.offsetcol, keys(X)))
-    data = Tables.table([Xmatrix y]; header=[header; :y])
-    return data
-end
-
-"""
-glm_report(fitresult)
+    glm_report(fitresult)
 
 Report based on the `fitresult` of a GLM model.
 """
@@ -145,7 +134,7 @@ const GLM_MODELS = Union{<:LinearRegressor, <:LinearBinaryClassifier, <:LinearCo
 """
     glm_formula(model, X) -> FormulaTerm
 
-Return formula which can be passed to `fit(formula, data, ...)`.
+Return formula which is ready to be passed to `fit(form, data, ...)`.
 """
 function glm_formula(model, X)::FormulaTerm
     # By default, using a JuliaStats formula will add an intercept.
@@ -154,6 +143,17 @@ function glm_formula(model, X)::FormulaTerm
     intercept_term = model.fit_intercept ? 1 : 0
     form = GLM.Term(:y) ~ sum(GLM.term.(keys(X))) + GLM.term(intercept_term)
     return form
+end
+
+"""
+    glm_data(model, Xmatrix, X, y)
+
+Return data which is ready to be passed to `fit(form, data, ...)`.
+"""
+function glm_data(model, Xmatrix, X, y)
+    header = collect(filter(x -> x != model.offsetcol, keys(X)))
+    data = Tables.table([Xmatrix y]; header=[header; :y])
+    return data
 end
 
 """

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -156,19 +156,6 @@ function glm_data(model, Xmatrix, X, y)
     return data
 end
 
-"""
-    glm_data(X, Xmatrix, y)
-
-Return data which can be passed to `fit(formula, data, ...)`.
-This should return a MatrixTable always, since NamedTuples cannot handle tensors.
-"""
-function glm_data(X, Xmatrix, y)
-    names = keys(X)
-    Xupdated = NamedTuple([names[i] => Xmatrix[:, i] for i in 1:length(names)])
-    data = (; Xupdated..., y=y)
-    return data
-end
-
 ####
 #### FIT FUNCTIONS
 ####

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -211,7 +211,7 @@ glm_fitresult(::LinearBinaryClassifier, fitresult) = fitresult[1]
 
 function MMI.fitted_params(model::GLM_MODELS, fitresult)
     result = glm_fitresult(model, fitresult)
-    coef = GLM.coef(result)[1:end-Int(model.fit_intercept)]
+    coef = GLM.coef(result)
     features = filter(name -> name != "(Intercept)", GLM.coefnames(result))
     intercept = model.fit_intercept ? coef[end] : nothing
     return (; features=features, coef=coef, intercept=intercept)

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -141,7 +141,8 @@ function glm_formula(model, X)::FormulaTerm
     # Adding a zero term explicitly disables the intercept.
     # See the StatsModels.jl tests for more information.
     intercept_term = model.fit_intercept ? 1 : 0
-    form = GLM.Term(:y) ~ sum(GLM.term.(keys(X))) + GLM.term(intercept_term)
+    features = filter(x -> x != model.offsetcol, keys(X))
+    form = GLM.Term(:y) ~ sum(GLM.term.(features)) + GLM.term(intercept_term)
     return form
 end
 

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -93,10 +93,13 @@ end
 
 Report based on the `fitresult` of a GLM model.
 """
-glm_report(fitresult) = ( deviance     = GLM.deviance(fitresult),
-                          dof_residual = GLM.dof_residual(fitresult),
-                          stderror     = GLM.stderror(fitresult),
-                          vcov         = GLM.vcov(fitresult) )
+function glm_report(fitresult)
+    deviance = GLM.deviance(fitresult)
+    dof_residual = GLM.dof_residual(fitresult)
+    stderror = GLM.stderror(fitresult)
+    vcov = GLM.vcov(fitresult)
+    return (; deviance=deviance, dof_residual=dof_residual, stderror=stderror, vcov=vcov)
+end
 
 ####
 #### REGRESSION TYPES
@@ -207,9 +210,11 @@ glm_fitresult(::LinearCountRegressor, fitresult) = fitresult
 glm_fitresult(::LinearBinaryClassifier, fitresult) = fitresult[1]
 
 function MMI.fitted_params(model::GLM_MODELS, fitresult)
-    coefs = GLM.coef(glm_fitresult(model,fitresult))
-    return (coef      = coefs[1:end-Int(model.fit_intercept)],
-            intercept = ifelse(model.fit_intercept, coefs[end], nothing))
+    result = glm_fitresult(model, fitresult)
+    coef = GLM.coef(result)[1:end-Int(model.fit_intercept)]
+    features = filter(name -> name != "(Intercept)", GLM.coefnames(result))
+    intercept = model.fit_intercept ? coef[end] : nothing
+    return (; features=features, coef=coef, intercept=intercept)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using MLJBase
 using LinearAlgebra
 using Statistics
 using MLJGLMInterface
+using GLM: coeftable
 import GLM
 
 import Distributions
@@ -141,10 +142,10 @@ end
         @test length(Xnew) == 2
     end
 
-    # In the following:
-    # The second column is taken as an offset by the model
-    # This is equivalent to assuming the coef is 1 and known 
-    
+    # In the following:
+    # The second column is taken as an offset by the model
+    # This is equivalent to assuming the coef is 1 and known
+
     @testset "Test Logistic regression with offset" begin
         N = 1000
         rng = StableRNGs.StableRNG(0)
@@ -184,4 +185,16 @@ end
 
         @test fp.coef ≈ [2, -1] atol=0.04
     end
+end
+
+@testset "Fitted param names" begin
+    # Test whether the names `a` and `b` are passed to `fitresult`.
+    X = (a=[1,2,3], b=[4,5,6], c=[9,7,11])
+    y = categorical([true, true, false])
+    lr = LinearBinaryClassifier(fit_intercept=false)
+    fitresult, _, _ = fit(lr, 1, X, y)
+    glmresult = first(fitresult)
+    ctable = coeftable(glmresult)
+    parameters = ctable.rownms
+    @test parameters == ["a", "b", "c"]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,7 @@ end
         fp = fitted_params(lr, fitresult)
 
         @test fp.coef ≈ [2, -1] atol=0.03
+        @test fp.intercept === nothing
     end
     @testset "Test Linear regression with offset" begin
         N = 1000
@@ -193,12 +194,14 @@ end
     lr = LinearBinaryClassifier(fit_intercept=true)
     fitresult, _, _ = fit(lr, 1, X, y)
     ctable = coeftable(first(fitresult))
-    parameters = ctable.rownms
+    parameters = ctable.rownms # Row names.
     @test parameters == ["a", "b", "c", "(Intercept)"]
+    intercept = ctable.cols[1][4]
     yhat = predict(lr, fitresult, X)
     @test mean(cross_entropy(yhat, y)) < 0.6
 
-    params = fitted_params(lr, fitresult)
-    @test params.features == ["a", "b", "c"]
-    @test :intercept in keys(params)
+    fp = fitted_params(lr, fitresult)
+    @test fp.features == ["a", "b", "c"]
+    @test :intercept in keys(fp)
+    @test intercept == fp.intercept
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
     @testset "intercept/offsetcol" for mt in modeltypes
             X = (x1=[1,2,3], x2=[4,5,6])
             m = mt(fit_intercept=true, offsetcol=:x2)
-            Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
+            Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X; handle_intercept=true)
 
             @test offset == [4, 5, 6]
             @test Xmatrix== [1 1;
@@ -119,7 +119,7 @@ modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
     @testset "no intercept/no offsetcol" for mt in modeltypes
         X = (x1=[1,2,3], x2=[4,5,6])
         m = mt(fit_intercept=false)
-        Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
+        Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X; handle_intercept=true)
 
         @test offset == []
         @test Xmatrix == [1 4;
@@ -192,10 +192,9 @@ end
     y = categorical([true, true, false, false])
     lr = LinearBinaryClassifier(fit_intercept=true)
     fitresult, _, _ = fit(lr, 1, X, y)
-    glmresult = first(fitresult)
-    ctable = coeftable(glmresult)
+    ctable = coeftable(first(fitresult))
     parameters = ctable.rownms
-    @test parameters == ["a", "b", "c"]
+    @test parameters == ["a", "b", "c", "(Intercept)"]
     yhat = predict(lr, fitresult, X)
-    @test mean(cross_entropy(yhat, y)) < 0.25
+    @test mean(cross_entropy(yhat, y)) < 0.6
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ model = atom_ols
 
 p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
-@test p_distr[1] == Distributions.Normal(p[1], GLM.dispersion(fitresult))
+@test p_distr[1] == Distributions.Normal(p[1], GLM.dispersion(fitresult.model))
 
 ###
 ### Logistic regression

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,7 +65,7 @@ rng = StableRNGs.StableRNG(0)
 N = 100
 X = MLJBase.table(rand(rng, N, 4));
 ycont = 2*X.x1 - X.x3 + 0.6*rand(rng, N)
-y = (ycont .> mean(ycont)) |> categorical;
+y = categorical(ycont .> mean(ycont))
 
 lr = LinearBinaryClassifier()
 fitresult, _, report = fit(lr, 1, X, y)
@@ -187,14 +187,15 @@ end
     end
 end
 
-@testset "Fitted param names" begin
-    # Test whether the names `a` and `b` are passed to `fitresult`.
-    X = (a=[1,2,3], b=[4,5,6], c=[9,7,11])
-    y = categorical([true, true, false])
-    lr = LinearBinaryClassifier(fit_intercept=false)
+@testset "Param names in fitresult" begin
+    X = (a=[1, 9, 4, 2], b=[1, 2, 1, 4], c=[9, 1, 5, 3])
+    y = categorical([true, true, false, false])
+    lr = LinearBinaryClassifier(fit_intercept=true)
     fitresult, _, _ = fit(lr, 1, X, y)
     glmresult = first(fitresult)
     ctable = coeftable(glmresult)
     parameters = ctable.rownms
     @test parameters == ["a", "b", "c"]
+    yhat = predict(lr, fitresult, X)
+    @test mean(cross_entropy(yhat, y)) < 0.25
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ Xtrain = selectrows(X, train)
 ytrain = selectrows(y, train)
 Xtest  = selectrows(X, test)
 
-fitresult, _, report = fit(atom_ols, 1, Xtrain, ytrain)
+fitresult, _, _ = fit(atom_ols, 1, Xtrain, ytrain)
 θ = MLJBase.fitted_params(atom_ols, fitresult)
 
 p = predict_mean(atom_ols, fitresult, Xtest)
@@ -197,4 +197,8 @@ end
     @test parameters == ["a", "b", "c", "(Intercept)"]
     yhat = predict(lr, fitresult, X)
     @test mean(cross_entropy(yhat, y)) < 0.6
+
+    params = fitted_params(lr, fitresult)
+    @test params.features == ["a", "b", "c"]
+    @test :intercept in keys(params)
 end


### PR DESCRIPTION
This PR changes the usage of `glm(X, y, ...)` to `glm(formula, data)` so that `fitresult` reports feature names in the output. For example, before this PR, the names of the features in fitresult where `:x1, :x2, ...`. Now, they take the name of the passed data and the `fitresult` shows the fitted formula:

```julia
julia> X = (; a=[1, 9, 4, 2], b=[1, 2, 1, 4], c=[9, 1, 5, 3]);

julia> y = categorical([true, true, false, false]);

julia> lr = LinearBinaryClassifier(fit_intercept=true);

julia> fitresult, _, _ = fit(lr, 1, X, y);

julia> fitresult[1]
StatsModels.TableRegressionModel{GLM.GeneralizedLinearModel{GLM.GlmResp{Vector{Float64}, Distributions.Bernoulli{Float64}, GLM.LogitLink}, GLM.DensePredChol{Float64, Cholesky{Float64, Matrix{Float64}}}}, Matrix{Float64}}

y ~ a + b + c + 1

Coefficients:
─────────────────────────────────────────────────────────────────────────
                 Coef.  Std. Error      z  Pr(>|z|)  Lower 95%  Upper 95%
─────────────────────────────────────────────────────────────────────────
a              19.1818     1525.99   0.01    0.9900   -2971.7     3010.07
b              27.9007     2951.02   0.01    0.9925   -5755.98    5811.79
c              22.6694     1902.78   0.01    0.9905   -3706.71    3752.05
(Intercept)  -234.541     20231.5   -0.01    0.9908  -39887.6    39418.6
─────────────────────────────────────────────────────────────────────────
```

**EDIT**: Also:
```julia
julia> fitted_params(lr, fitresult)
(features = ["a", "b", "c"],
 coef = [19.181763436540795, 27.90074681678668, 22.669356788639142, -234.54065292861273],
 intercept = -234.54065292861273,)
```

Note 2: most of the logic is about handling `offset`. I doubt whether it is necessary to manually handle `offset`. Might be related to https://github.com/JuliaStats/GLM.jl/issues/306.





