### PR TITLE
fix bug in requesting keys of table sources

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJGLMInterface"
 uuid = "caf8df21-4939-456d-ac9c-5fefbfb04c0c"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.7"
+version = "0.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ GLM = "^1.3.11"
 MLJModelInterface = "0.3.6, 0.4, 1"
 Parameters = "^0.12"
 Tables = "^1.1"
-julia = "^1"
+julia = "^1.3"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
With the previous code `keys` method was called on `Tables.jl` input sources (`X`) rather on their corresponding `AbstractColumns`(i.e `Tables.colums(X)`) or `AbstractRow`(i.e `iterate(Tables.rows(X), 1)[1]`) objects. This PR fixes this.

Fixes https://github.com/JuliaAI/DataScienceTutorials.jl/issues/177
cc. @tlienart 