### PR TITLE
breaking changes to MLJGLMInterface.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.2"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Distributions = "0.23, 0.24, 0.25"
 GLM = "^1.3.11"
 MLJModelInterface = "0.3.6, 0.4, 1"
-Parameters = "^0.12"
 Tables = "^1.1"
 julia = "^1.3"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,131 +15,300 @@ using Tables
 expit(X) = 1 ./ (1 .+ exp.(-X))
 
 ###
-### OLSREGRESSOR
+### END-TO-END TESTS
 ###
+@testset "OLSREGRESSOR" begin
+    X, y = @load_boston
 
-X, y = @load_boston
+    train, test = partition(eachindex(y), 0.7)
 
-train, test = partition(eachindex(y), 0.7)
+    atom_ols = LinearRegressor()
 
-atom_ols = LinearRegressor()
+    Xtrain = selectrows(X, train)
+    ytrain = selectrows(y, train)
+    Xtest  = selectrows(X, test)
 
-Xtrain = selectrows(X, train)
-ytrain = selectrows(y, train)
-Xtest  = selectrows(X, test)
+    # Without weights `w`
+    fitresult, _, _ = fit(atom_ols, 1, Xtrain, ytrain)
+    θ = MLJBase.fitted_params(atom_ols, fitresult)
 
-fitresult, _, _ = fit(atom_ols, 1, Xtrain, ytrain)
-θ = MLJBase.fitted_params(atom_ols, fitresult)
+    p = predict_mean(atom_ols, fitresult, Xtest)
 
-p = predict_mean(atom_ols, fitresult, Xtest)
+    # With weihts `w`
+    fitresultw, _, _ = fit(atom_ols, 1, Xtrain, ytrain, ones(eltype(ytrain), length(ytrain)))
+    θw = MLJBase.fitted_params(atom_ols, fitresult)
 
-# hand made regression to compare
+    pw = predict_mean(atom_ols, fitresultw, Xtest)
 
-Xa = MLJBase.matrix(X) # convert(Matrix{Float64}, X)
-Xa1 = hcat(Xa, ones(size(Xa, 1)))
-coefs = Xa1[train, :] \ y[train]
-p2 = Xa1[test, :] * coefs
+    # hand made regression to compare
 
-@test p ≈ p2
+    Xa = MLJBase.matrix(X) # convert(Matrix{Float64}, X)
+    Xa1 = hcat(Xa, ones(size(Xa, 1)))
+    coefs = Xa1[train, :] \ y[train]
+    p2 = Xa1[test, :] * coefs
 
-model = atom_ols
-@test name(model) == "LinearRegressor"
-@test package_name(model) == "GLM"
-@test is_pure_julia(model)
-@test is_supervised(model)
-@test package_license(model) == "MIT"
-@test prediction_type(model) == :probabilistic
-@test hyperparameters(model) == (:fit_intercept, :allowrankdeficient, :offsetcol)
-@test hyperparameter_types(model) == ("Bool", "Bool", "Union{Nothing, Symbol}")
+    @test p ≈ p2
+    @test pw ≈ p2
 
-p_distr = predict(atom_ols, fitresult, selectrows(X, test))
+    p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
-@test p_distr[1] == Distributions.Normal(p[1], GLM.dispersion(fitresult.model))
+    @test p_distr[1] == Distributions.Normal(
+        p[1], MLJGLMInterface.dispersion(fitresult))
 
-###
-### Logistic regression
-###
+    # check predict on `Xtest1` with wrong dims
+    Xtest1 = MLJBase.table(Tables.matrix(Xtest)[:, 1:3], names=Tables.columnnames(Xtest)[1:3])
+    @test_throws DimensionMismatch predict(atom_ols, fitresult, Xtest1)
+    # check exact match of features during predict
+    atom_ols.check_features = true
+    Xtest2 = MLJBase.table(
+        Tables.matrix(Xtest), names=[Symbol("p$i") for i in eachindex(Tables.columnnames(Xtest))]
+    )
+    @test_throws ArgumentError predict(atom_ols, fitresult, Xtest2)
 
-rng = StableRNGs.StableRNG(0)
+    # Test metadata
+    model = atom_ols
+    @test name(model) == "LinearRegressor"
+    @test package_name(model) == "GLM"
+    @test supports_weights(model)
+    @test is_pure_julia(model)
+    @test is_supervised(model)
+    @test package_license(model) == "MIT"
+    @test prediction_type(model) == :probabilistic
+    @test hyperparameters(model) == (
+        :fit_intercept, :dropcollinear, :offsetcol, :report_params, :check_features
+    )
+    @test hyperparameter_types(model) == (
+        "Bool",
+        "Bool",
+        "Union{Nothing, Symbol}",
+        "Union{Nothing, AbstractVector{Symbol}}",
+        "Bool"
+    )
 
-N = 100
-X = MLJBase.table(rand(rng, N, 4));
-ycont = 2*X.x1 - X.x3 + 0.6*rand(rng, N)
-y = categorical(ycont .> mean(ycont))
-
-lr = LinearBinaryClassifier()
-fitresult, _, report = fit(lr, 1, X, y)
-
-yhat = predict(lr, fitresult, X)
-@test mean(cross_entropy(yhat, y)) < 0.25
-
-pr = LinearBinaryClassifier(link=GLM.ProbitLink())
-fitresult, _, report = fit(pr, 1, X, y)
-yhat = predict(lr, fitresult, X)
-@test mean(cross_entropy(yhat, y)) < 0.25
-
-fitted_params(pr, fitresult)
-
-
-###
-### Count regression
-###
-
-rng = StableRNGs.StableRNG(123)
-
-X = randn(rng, 500, 5)
-θ = randn(rng, 5)
-y = map(exp.(X*θ)) do mu
-    rand(rng, Distributions.Poisson(mu))
 end
 
-XTable = MLJBase.table(X)
+@testset "Logistic regression" begin
+    rng = StableRNGs.StableRNG(0)
 
-lcr = LinearCountRegressor(fit_intercept=false)
-fitresult, _, _ = fit(lcr, 1, XTable, y)
+    N = 100
+    X = MLJBase.table(rand(rng, N, 4));
+    ycont = 2*X.x1 - X.x3 + 0.6*rand(rng, N)
+    y = categorical(ycont .> mean(ycont))
 
-θ̂ = fitted_params(lcr, fitresult).coef
+    lr = LinearBinaryClassifier()
+    fitresult, _, report = fit(lr, 1, X, y)
 
-@test norm(θ̂ .- θ)/norm(θ) ≤ 0.03
+    yhat = predict(lr, fitresult, X)
+    @test mean(cross_entropy(yhat, y)) < 0.25
+
+    pr = LinearBinaryClassifier(link=GLM.ProbitLink())
+
+    # Without weights
+    fitresult, _, report = fit(pr, 1, X, y)
+    yhat = predict(lr, fitresult, X)
+    @test mean(cross_entropy(yhat, y)) < 0.25
+
+    # With weights
+    fitresultw, _, reportw = fit(pr, 1, X, y)
+    yhatw = predict(lr, fitresultw, X)
+    @test mean(cross_entropy(yhatw, y)) < 0.25
+    @test yhatw ≈ yhat
+
+    fitted_params(pr, fitresult)
+
+    # check predict on `Xnew` with wrong dims
+    Xnew = MLJBase.table(Tables.matrix(X)[:, 1:3], names=Tables.columnnames(X)[1:3])
+    @test_throws DimensionMismatch predict(lr, fitresult, Xnew)
+    # check exact match of features during predict
+    lr.check_features = true
+    Xnew1 = MLJBase.table(
+        Tables.matrix(X), names=[Symbol("p$i") for i in eachindex(Tables.columnnames(X))]
+    )
+    @test_throws ArgumentError predict(lr, fitresult, Xnew1)
+
+    # Test metadata
+    model = lr
+    @test name(model) == "LinearBinaryClassifier"
+    @test package_name(model) == "GLM"
+    @test supports_weights(model)
+    @test is_pure_julia(model)
+    @test is_supervised(model)
+    @test package_license(model) == "MIT"
+    @test prediction_type(model) == :probabilistic
+    @test hyperparameters(model) == (
+        :fit_intercept,
+        :link, 
+        :offsetcol,
+        :maxiter,
+        :atol,
+        :rtol,
+        :minstepfac,
+        :report_params,
+        :check_features
+    )
+    @test hyperparameter_types(model) == (
+        "Bool",
+        "$(GLM.Link01)",
+        "Union{Nothing, Symbol}",
+        "Integer",
+        "Real",
+        "Real",
+        "Real",
+        "Union{Nothing, AbstractVector{Symbol}}",
+        "Bool"
+    )
+end
+
+@testset "Count regression" begin
+    rng = StableRNGs.StableRNG(123)
+
+    X = randn(rng, 500, 5)
+    θ = randn(rng, 5)
+    y = map(exp.(X*θ)) do mu
+        rand(rng, Distributions.Poisson(mu))
+    end
+
+    XTable = MLJBase.table(X)
+
+    lcr = LinearCountRegressor(fit_intercept=false)
+
+    # Without weights
+    fitresult, _, _ = fit(lcr, 1, XTable, y)
+    θ̂ = fitted_params(lcr, fitresult).coef
+    @test norm(θ̂ .- θ)/norm(θ) ≤ 0.03
+
+    # With weights
+    fitresultw, _, _ = fit(lcr, 1, XTable, y)
+    θ̂w = fitted_params(lcr, fitresultw).coef
+    @test norm(θ̂w .- θ)/norm(θ) ≤ 0.03
+
+    # check predict on `Xnew` with wrong dims
+    Xnew = MLJBase.table(Tables.matrix(XTable)[:, 1:3], names=Tables.columnnames(XTable)[1:3])
+    @test_throws DimensionMismatch predict(lcr, fitresult, Xnew)
+    # check exact match of features during predict
+    lcr.check_features = true
+    Xnew1 = MLJBase.table(
+        Tables.matrix(XTable),
+        names=[Symbol("p$i") for i in eachindex(Tables.columnnames(XTable))]
+    )
+    @test_throws ArgumentError predict(lcr, fitresult, Xnew1)
+
+    # Test metadata
+    model = lcr
+    @test name(model) == "LinearCountRegressor"
+    @test package_name(model) == "GLM"
+    @test supports_weights(model)
+    @test is_pure_julia(model)
+    @test is_supervised(model)
+    @test package_license(model) == "MIT"
+    @test prediction_type(model) == :probabilistic
+    @test hyperparameters(model) == (
+        :fit_intercept,
+        :distribution,
+        :link, 
+        :offsetcol,
+        :maxiter,
+        :atol,
+        :rtol,
+        :minstepfac,
+        :report_params,
+        :check_features
+    )
+    @test hyperparameter_types(model) == (
+        "Bool",
+        "$(Distributions.Distribution)",
+        "$(GLM.Link)",
+        "Union{Nothing, Symbol}",
+        "Integer",
+        "Real",
+        "Real",
+        "Real",
+        "Union{Nothing, AbstractVector{Symbol}}",
+        "Bool"
+    )
+
+end
 
 
-modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
+###
+### Unit tests
+###
+const modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
 @testset "Test prepare_inputs" begin
     @testset "intercept/offsetcol" for mt in modeltypes
             X = (x1=[1,2,3], x2=[4,5,6])
             m = mt(fit_intercept=true, offsetcol=:x2)
-            Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X; handle_intercept=true)
+            Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
 
             @test offset == [4, 5, 6]
-            @test Xmatrix== [1 1;
-                             2 1;
-                             3 1]
+            @test Xmatrix== [
+                1 1;
+                2 1;
+                3 1
+            ]
+            # try different tables
+            X2 = Tables.table(Tables.matrix(X), header=Tables.columnnames(X))::Tables.MatrixTable
+            Xmatrix2, offset2 = MLJGLMInterface.prepare_inputs(m, X2)
+            @test offset2 == offset
+            @test Xmatrix2 == Xmatrix
+
+            X3 = Tables.Columns(X)::Tables.Columns
+            Xmatrix3, offset3 = MLJGLMInterface.prepare_inputs(m, X3)
+            @test offset3 == offset
+            @test Xmatrix3 == Xmatrix
+            
+            # throw error when offsetcol isn't present in table
+            m1 = mt(fit_intercept=true, offsetcol=:x3)
+            @test_throws ArgumentError MLJGLMInterface.prepare_inputs(m1, X)
     end
 
     @testset "no intercept/no offsetcol" for mt in modeltypes
         X = (x1=[1,2,3], x2=[4,5,6])
         m = mt(fit_intercept=false)
-        Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X; handle_intercept=true)
+        Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
 
         @test offset == []
-        @test Xmatrix == [1 4;
-                          2 5;
-                          3 6]
+        @test Xmatrix == [
+            1 4;
+            2 5;
+            3 6
+        ]
+
+        # throw error when fitting table with no columns `e.g NamedTuple()`
+        X1 = NamedTuple()
+        @test_throws ArgumentError MLJGLMInterface.prepare_inputs(m, X1)
+        
     end
 
-end
+    @testset "offsetcol but no intercept" for mt in modeltypes
+        X = (x1=[1,2,3], x2=[4,5,6])
+        m = mt(offsetcol=:x1, fit_intercept=false)
+        Xmatrix, offset = MLJGLMInterface.prepare_inputs(m, X)
 
+        @test offset == [1, 2, 3]
+        @test Xmatrix == permutedims([4 5 6])
+
+        # throw error for tables with just one column and for which 
+        # `offsetcol !== nothing` and `fit_intercept == false`
+        # as at least two columns would be required in this case.
+        X1 = (x1=[1,2,3],)
+        @test_throws ArgumentError MLJGLMInterface.prepare_inputs(m, X1)
+    end
+end
 
 @testset "Test offsetting models" begin
     @testset "Test split_X_offset" begin
+        rng = StableRNGs.StableRNG(123)
+        N = 100
         X = (x1=[1,2,3], x2=[4,5,6])
-        @test MLJGLMInterface.split_X_offset(X, nothing) == (X, Float64[])
-        @test MLJGLMInterface.split_X_offset(X, :x1) == ((x2=[4,5,6],), [1,2,3])
+        @test MLJGLMInterface.split_X_offset(X, nothing) == (X, Float64[], [:x1, :x2])
+        @test MLJGLMInterface.split_X_offset(X, :x1) == ((x2=[4,5,6],), [1,2,3], [:x2,])
 
         X = MLJBase.table(rand(rng, N, 3))
-        Xnew, offset = MLJGLMInterface.split_X_offset(X, :x2)
+        Xnew, offset, X_features = MLJGLMInterface.split_X_offset(X, :x2)
         @test offset isa Vector
         @test length(Xnew) == 2
+        @test X_features isa Vector{Symbol}
     end
 
     # In the following:
@@ -158,8 +327,9 @@ end
         fp = fitted_params(lr, fitresult)
 
         @test fp.coef ≈ [2, -1] atol=0.03
-        @test fp.intercept === nothing
+        @test iszero(fp.intercept)
     end
+
     @testset "Test Linear regression with offset" begin
         N = 1000
         rng = StableRNGs.StableRNG(0)
@@ -188,20 +358,46 @@ end
     end
 end
 
-@testset "Param names in fitresult" begin
+@testset "Param names in fitresult/report" begin
     X = (a=[1, 9, 4, 2], b=[1, 2, 1, 4], c=[9, 1, 5, 3])
     y = categorical([true, true, false, false])
     lr = LinearBinaryClassifier(fit_intercept=true)
-    fitresult, _, _ = fit(lr, 1, X, y)
-    ctable = coeftable(first(fitresult))
+    fitresult, _, report = fit(lr, 1, X, y)
+    # by default `report` contains every training stats about the fit
+    @test :deviance in keys(report) 
+    @test :dof_residual in keys(report)
+    @test :stderror in keys(report)
+    @test :vcov in keys(report)
+    @test :coef_table in keys(report)
+    ctable = last(report)
     parameters = ctable.rownms # Row names.
     @test parameters == ["a", "b", "c", "(Intercept)"]
     intercept = ctable.cols[1][4]
+    coef = ctable.cols[1][1:3]
     yhat = predict(lr, fitresult, X)
     @test mean(cross_entropy(yhat, y)) < 0.6
 
     fp = fitted_params(lr, fitresult)
-    @test fp.features == ["a", "b", "c"]
+    @test :coef in keys(fp)
+    @test fp.coef == coef
+    @test :feature_names in keys(fp)
+    @test fp.feature_names == [:a, :b, :c]
     @test :intercept in keys(fp)
     @test intercept == fp.intercept
+
+    # test when `fit_intercept` is false
+    lr = LinearBinaryClassifier(fit_intercept=false)
+    fitresult, _, report = fit(lr, 1, X, y)
+    ctable = last(report)
+    parameters = ctable.rownms # Row names.
+    @test parameters == ["a", "b", "c"]
+    coef = ctable.cols[1][1:3]
+    fp = fitted_params(lr, fitresult)
+    @test :coef in keys(fp)
+    @test fp.coef == coef
+    @test :feature_names in keys(fp)
+    @test fp.feature_names == [:a, :b, :c]
+    @test :intercept in keys(fp)
+    @test fp.intercept == 0
+
 end


### PR DESCRIPTION
This PR includes quite a number of breaking and non-breaking changes. These changes include:
1. Remove `Parameters.jl` dependency: This dependency is no longer required as the macro `@with_kw_noshow`  is also been removed in this PR. The `@with_kw_noshow` macro has been replace with `@mlj_model` macro. This PR also get's rid of type parameters in the model structs, which could affect hyperparameter tuning of these models as type parameters (although helpful in performance) restrict the range of objects an hyper-parameter could take. 
2. Introduces a new fit return object `FitResult` which houses the glm model coefficients (including intercept), dispersion parameter of the glm distribution, and any other fit result that may be specific to a given glm model. This has the advantage that it no longer houses the fit data, hence allowing serialization of only the key components of a model.
3. Switch from formula call to matrix: Prior to this PR `MLJGLMInterface` `fit` method at its core makes a call to `glm(formula, data, distr::UnivariateDistribution, link::Link = canonicallink(d); <keyword arguments>)` where `data` is a table containing the features and also includes the target column. This PR replaces this call with  ` glm(X::AbstractMatrix, y::AbstractVector, distr::UnivariateDistribution, link::Link = canonicallink(d); <keyword arguments>)` where `X` is the feature matrix(with a column of ones appended at the end if `intercept` is being fitted), and `y` is the the target vector. This has the advantage of avoiding unnecessary costly allocations that result from manually having to create a table that includes features only to split such a table latter on.
4. added a new internal method `_to_matrix` which is a more efficient way of converting a Table to a matrix and also adjusting the matrix when the model also fits an intercept.
5. Added extra checks on the data which catches bugs there were previously waiting to be uncovered. For example for the case where one trains a glm model with an offset column set (i.e `model.offsetcol !== nothing`), `fit_intercept==false` and a dataset containing one feature and one target, wouldn't make any sense and this PR throws (hopefully) and informative error message as to why. Also fitting glm models on dataset containing more features than observations would lead to incorrect results, so checks are in place to throw errors in this case.
6. Allow users to customize the `report`: This PR also allows the user to customize the report with the `report_parms` model hyper-parameter, there are several options available  for example setting `report_params = nothing` which returns an empty `NamedTuple` (indicating no report/statistic was computed). `report_params` can also be an instance of `Vector{Symbol}` with elements being members of `[:deviance, :dof_residual, :stderror, :vcov, :coef_table]`. By default all possible options are computed in the report. 
7. As a result of (2) and (6) above, the nice nice view of the cool glm coefficient table introduced in https://github.com/JuliaAI/MLJGLMInterface.jl/pull/12, is no longer the display of the `fitresult`. This has been instead been moved to one of the optional items to be added to the `report`.
8. The PR also fixes a bug in `LinearRegressor` model: This model accepts the keyword argument `allowrankdeficient` which was never used during the fit. So this PR incorporates fixes this by replacing this kwarg with the more recent `dropcollinear` (Derived from GLM package) and taking account of this keyword argument during the fit by replacing the `GLM.glm` method with `GLM.lm` method.
9. Finally this PR adds supports for observation weights to all implemented GLM models. These weight are directly passed to the GLM models. According to the GLM package documentation 
> Such weights are equivalent to repeating each observation a number of times equal to its weight. Do note that this interpretation gives equal point estimates but different standard errors from analytical (a.k.a. inverse variance) weights and from probability (a.k.a. sampling) weights which are the default in some other software.

cc. @ablaom , @rikhuijzer.
