### PR TITLE
Set minimum version to Julia 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
     tags: '*'
+  workflow_dispatch:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -15,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
-          - '1'
+          - '1.6'
+          - '1' # Julia latest
         os:
           - ubuntu-latest
         arch:
@@ -27,16 +28,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ GLM = "^1.3.11"
 MLJModelInterface = "0.3.6, 0.4, 1"
 Parameters = "^0.12"
 Tables = "^1.1"
-julia = "^1.3"
+julia = "1.6"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
MLJBase has already moved, I see (https://github.com/JuliaAI/MLJBase.jl). So, we can bump this version too without problems.