### PR TITLE
Remove `Parameters.jl` dependency and refactor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
       - master
+      - dev
   push:
     branches:
       - master
+      - dev
     tags: '*'
   workflow_dispatch:
 jobs:

--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,12 @@ version = "0.2"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Distributions = "0.23, 0.24, 0.25"
 GLM = "^1.3.11"
 MLJModelInterface = "0.3.6, 0.4, 1"
-Parameters = "^0.12"
 Tables = "^1.1"
 julia = "^1.3"
 

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -21,7 +21,6 @@ import Distributions
 using Tables
 import GLM
 using GLM: FormulaTerm
-using Parameters
 
 const MMI = MLJModelInterface
 const PKG = "MLJGLMInterface"
@@ -47,24 +46,22 @@ const LCR_DESCR = "Linear count regressor with specified "*
 # MulticlassClassifier   --> Probabilistic w Multiclass target
 
 
-@with_kw_noshow mutable struct LinearRegressor <: MMI.Probabilistic
+@mlj_model mutable struct LinearRegressor <: MMI.Probabilistic
     fit_intercept::Bool = true
     allowrankdeficient::Bool = false
     offsetcol::Union{Symbol, Nothing} = nothing
 end
 
-@with_kw_noshow mutable struct LinearBinaryClassifier{L<:GLM.Link01} <: MMI.Probabilistic
+@mlj_model mutable struct LinearBinaryClassifier <: MMI.Probabilistic
     fit_intercept::Bool = true
-    link::L = GLM.LogitLink()
+    link::GLM.Link01 = GLM.LogitLink()
     offsetcol::Union{Symbol, Nothing} = nothing
 end
 
-@with_kw_noshow mutable struct LinearCountRegressor{
-    D<:Distributions.Distribution,L<:GLM.Link
-} <: MMI.Probabilistic
+@mlj_model mutable struct LinearCountRegressor <: MMI.Probabilistic
     fit_intercept::Bool = true
-    distribution::D = Distributions.Poisson()
-    link::L = GLM.LogLink()
+    distribution::Distributions.Distribution = Distributions.Poisson()
+    link::GLM.Link = GLM.LogLink()
     offsetcol::Union{Symbol, Nothing} = nothing
 end
 

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -188,10 +188,7 @@ function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
     features = glm_features(model, X)
     data = glm_data(model, Xmatrix, y, features)
     form = glm_formula(model, features)
-    fitresult = GLM.glm(
-        form, data, Distributions.Normal(), GLM.IdentityLink();
-        offset=offset
-    )
+    fitresult = GLM.glm(form, data, Distributions.Normal(), GLM.IdentityLink(); offset)
     # form the report
     report = glm_report(fitresult)
     cache = nothing
@@ -205,10 +202,7 @@ function MMI.fit(model::LinearCountRegressor, verbosity::Int, X, y)
     features = glm_features(model, X)
     data = glm_data(model, Xmatrix, y, features)
     form = glm_formula(model, features)
-    fitresult = GLM.glm(
-        form, data, model.distribution, model.link;
-        offset=offset
-    )
+    fitresult = GLM.glm(form, data, model.distribution, model.link; offset)
     # form the report
     report = glm_report(fitresult)
     cache = nothing
@@ -224,10 +218,7 @@ function MMI.fit(model::LinearBinaryClassifier, verbosity::Int, X, y)
     features = glm_features(model, X)
     data = glm_data(model, Xmatrix, y_plain, features)
     form = glm_formula(model, features)
-    fitresult = GLM.glm(
-        form, data, Distributions.Bernoulli(), model.link;
-        offset=offset
-    )
+    fitresult = GLM.glm(form, data, Distributions.Bernoulli(), model.link; offset)
     # form the report
     report = glm_report(fitresult)
     cache = nothing
@@ -255,12 +246,12 @@ end
 # more efficient than MLJBase fallback
 function MMI.predict_mean(model::Union{LinearRegressor,<:LinearCountRegressor}, fitresult, Xnew)
     Xmatrix, offset = prepare_inputs(model, Xnew; handle_intercept=true)
-    return GLM.predict(fitresult, Xmatrix; offset=offset)
+    return GLM.predict(fitresult, Xmatrix; offset)
 end
 
 function MMI.predict_mean(model::LinearBinaryClassifier, (fitresult, _), Xnew)
     Xmatrix, offset = prepare_inputs(model, Xnew; handle_intercept=true)
-    return GLM.predict(fitresult.model, Xmatrix; offset=offset)
+    return GLM.predict(fitresult.model, Xmatrix; offset)
 end
 
 function MMI.predict(model::LinearRegressor, fitresult, Xnew)

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -15,9 +15,8 @@ module MLJGLMInterface
 export LinearRegressor, LinearBinaryClassifier, LinearCountRegressor
 
 import MLJModelInterface
-import MLJModelInterface: metadata_pkg, metadata_model,
-                          Table, Continuous, Count, Finite, OrderedFactor,
-                          Multiclass, @mlj_model
+import MLJModelInterface: metadata_pkg, metadata_model, Table, Continuous, Count, Finite,
+    OrderedFactor, Multiclass, @mlj_model
 import Distributions
 using Tables
 import GLM
@@ -37,6 +36,43 @@ const LBC_DESCR = "Linear binary classifier with "*
 const LCR_DESCR = "Linear count regressor with specified "*
     "link and distribution (e.g. log link and poisson)."
 
+
+####
+#### REGRESSION TYPES
+####
+
+# LinearRegressor        --> Probabilistic w Continuous Target
+# LinearCountRegressor   --> Probabilistic w Count Target
+# LinearBinaryClassifier --> Probabilistic w Binary target // logit,cauchit,..
+# MulticlassClassifier   --> Probabilistic w Multiclass target
+
+
+@with_kw_noshow mutable struct LinearRegressor <: MMI.Probabilistic
+    fit_intercept::Bool = true
+    allowrankdeficient::Bool = false
+    offsetcol::Union{Symbol, Nothing} = nothing
+end
+
+@with_kw_noshow mutable struct LinearBinaryClassifier{L<:GLM.Link01} <: MMI.Probabilistic
+    fit_intercept::Bool = true
+    link::L = GLM.LogitLink()
+    offsetcol::Union{Symbol, Nothing} = nothing
+end
+
+@with_kw_noshow mutable struct LinearCountRegressor{
+    D<:Distributions.Distribution,L<:GLM.Link
+} <: MMI.Probabilistic
+    fit_intercept::Bool = true
+    distribution::D = Distributions.Poisson()
+    link::L = GLM.LogLink()
+    offsetcol::Union{Symbol, Nothing} = nothing
+end
+
+# Short names for convenience here
+
+const GLM_MODELS = Union{
+    <:LinearRegressor, <:LinearBinaryClassifier, <:LinearCountRegressor
+}
 
 ###
 ## Helper functions
@@ -101,38 +137,6 @@ function glm_report(fitresult)
     return (; deviance=deviance, dof_residual=dof_residual, stderror=stderror, vcov=vcov)
 end
 
-####
-#### REGRESSION TYPES
-####
-
-# LinearRegressor        --> Probabilistic w Continuous Target
-# LinearCountRegressor   --> Probabilistic w Count Target
-# LinearBinaryClassifier --> Probabilistic w Binary target // logit,cauchit,..
-# MulticlassClassifier   --> Probabilistic w Multiclass target
-
-
-@with_kw_noshow mutable struct LinearRegressor <: MMI.Probabilistic
-    fit_intercept::Bool                 = true
-    allowrankdeficient::Bool            = false
-    offsetcol::Union{Symbol, Nothing}   = nothing
-end
-
-@with_kw_noshow mutable struct LinearBinaryClassifier{L<:GLM.Link01} <: MMI.Probabilistic
-    fit_intercept::Bool                 = true
-    link::L                             = GLM.LogitLink()
-    offsetcol::Union{Symbol, Nothing}   = nothing
-end
-
-@with_kw_noshow mutable struct LinearCountRegressor{D<:Distributions.Distribution,L<:GLM.Link} <: MMI.Probabilistic
-    fit_intercept::Bool                 = true
-    distribution::D                     = Distributions.Poisson()
-    link::L                             = GLM.LogLink()
-    offsetcol::Union{Symbol, Nothing}   = nothing
-end
-
-# Short names for convenience here
-
-const GLM_MODELS = Union{<:LinearRegressor, <:LinearBinaryClassifier, <:LinearCountRegressor}
 
 """
     glm_formula(model, features) -> FormulaTerm
@@ -187,7 +191,10 @@ function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
     features = glm_features(model, X)
     data = glm_data(model, Xmatrix, y, features)
     form = glm_formula(model, features)
-    fitresult = GLM.glm(form, data, Distributions.Normal(), GLM.IdentityLink(); offset=offset)
+    fitresult = GLM.glm(
+        form, data, Distributions.Normal(), GLM.IdentityLink();
+        offset=offset
+    )
     # form the report
     report = glm_report(fitresult)
     cache = nothing
@@ -201,7 +208,10 @@ function MMI.fit(model::LinearCountRegressor, verbosity::Int, X, y)
     features = glm_features(model, X)
     data = glm_data(model, Xmatrix, y, features)
     form = glm_formula(model, features)
-    fitresult = GLM.glm(form, data, model.distribution, model.link; offset=offset)
+    fitresult = GLM.glm(
+        form, data, model.distribution, model.link;
+        offset=offset
+    )
     # form the report
     report = glm_report(fitresult)
     cache = nothing
@@ -217,7 +227,10 @@ function MMI.fit(model::LinearBinaryClassifier, verbosity::Int, X, y)
     features = glm_features(model, X)
     data = glm_data(model, Xmatrix, y_plain, features)
     form = glm_formula(model, features)
-    fitresult = GLM.glm(form, data, Distributions.Bernoulli(), model.link; offset=offset)
+    fitresult = GLM.glm(
+        form, data, Distributions.Bernoulli(), model.link;
+        offset=offset
+    )
     # form the report
     report = glm_report(fitresult)
     cache = nothing
@@ -276,41 +289,45 @@ end
 ####
 
 # shared metadata
-const GLM_REGS = Union{Type{<:LinearRegressor},
-                       Type{<:LinearBinaryClassifier},
-                       Type{<:LinearCountRegressor}}
+const GLM_REGS = Union{
+    Type{<:LinearRegressor}, Type{<:LinearBinaryClassifier}, Type{<:LinearCountRegressor}
+}
 
-metadata_pkg.((LinearRegressor, LinearBinaryClassifier, LinearCountRegressor),
-              name       = "GLM",
-              uuid       = "38e38edf-8417-5370-95a0-9cbb8c7f171a",
-              url        = "https://github.com/JuliaStats/GLM.jl",
-              julia      = true,
-              license    = "MIT",
-              is_wrapper = false
-              )
+metadata_pkg.(
+    (LinearRegressor, LinearBinaryClassifier, LinearCountRegressor),
+    name = "GLM",
+    uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a",
+    url = "https://github.com/JuliaStats/GLM.jl",
+    julia = true,
+    license = "MIT",
+    is_wrapper = false
+)
 
-metadata_model(LinearRegressor,
-               input   = Table(Continuous),
-               target  = AbstractVector{Continuous},
-               weights = false,
-               descr   = LR_DESCR,
-               path    = "$PKG.LinearRegressor"
-               )
+metadata_model(
+    LinearRegressor,
+    input = Table(Continuous),
+    target = AbstractVector{Continuous},
+    weights = false,
+    descr = LR_DESCR,
+    path = "$PKG.LinearRegressor"
+)
 
-metadata_model(LinearBinaryClassifier,
-               input   = Table(Continuous),
-               target  = AbstractVector{<:Finite{2}},
-               weights = false,
-               descr   = LBC_DESCR,
-               path    = "$PKG.LinearBinaryClassifier"
-               )
+metadata_model(
+    LinearBinaryClassifier,
+    input = Table(Continuous),
+    target = AbstractVector{<:Finite{2}},
+    weights = false,
+    descr = LBC_DESCR,
+    path = "$PKG.LinearBinaryClassifier"
+)
 
-metadata_model(LinearCountRegressor,
-               input   = Table(Continuous),
-               target  = AbstractVector{Count},
-               weights = false,
-               descr   = LCR_DESCR,
-               path    = "$PKG.LinearCountRegressor"
-               )
+metadata_model(
+    LinearCountRegressor,
+    input = Table(Continuous),
+    target = AbstractVector{Count},
+    weights = false,
+    descr = LCR_DESCR,
+    path = "$PKG.LinearCountRegressor"
+)
 
 end # module


### PR DESCRIPTION
This is the first PR in a series of PRs to come which would include quite a number changes to **MLJGLMInterface**. 
this PR.
1. Re-organizes code so that it adheres more closely with https://github.com/invenia/BlueStyle formatting. 
2. Replaces the `@with_kw_noshow` macro with the more standard `@mlj_model` macro and removes the `Parameters.jl` dependency. This PR also get's rid of type parameters in the model structs, which could affect hyperparameter tuning of these models as type parameters (although helpful in performance) restrict the range of objects an hyper-parameter could take.

I'll release the next PR as soon as this gets merged.

cc. @ablaom , @rikhuijzer 
