### PR TITLE
fix bug in LinearRegressor model fit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Distributions = "0.23, 0.24, 0.25"
-GLM = "^1.4.0"
+GLM = "1.4"
 MLJModelInterface = "0.3.6, 0.4, 1"
 Tables = "^1.1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Distributions = "0.23, 0.24, 0.25"
-GLM = "^1.3.11"
+GLM = "^1.4.0"
 MLJModelInterface = "0.3.6, 0.4, 1"
 Tables = "^1.1"
 julia = "1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ model = atom_ols
 @test is_supervised(model)
 @test package_license(model) == "MIT"
 @test prediction_type(model) == :probabilistic
-@test hyperparameters(model) == (:fit_intercept, :allowrankdeficient, :offsetcol)
+@test hyperparameters(model) == (:fit_intercept, :dropcollinear, :offsetcol)
 @test hyperparameter_types(model) == ("Bool", "Bool", "Union{Nothing, Symbol}")
 
 p_distr = predict(atom_ols, fitresult, selectrows(X, test))


### PR DESCRIPTION
This PR fixes a bug in `LinearRegressor` model. Prior to this PR the `LinearRegressor` model accepted the `allowrankdeficient` keyword argument  which was never used during the fit, and mislead any user depending on such functionality. 
The fix in this PR replaces the `allowrankdeficient` kwarg with the more recent `dropcollinear` kwarg (Derived from GLM package >=v1.40). In order for the `dropcollinear` keyword argument to take effect during model fitting, the underlying GLM fit call was changed from the `GLM.glm` call to the `GLM.lm` call.

cc. @rikhuijzer , @ablaom 
