### PR TITLE
Introduce a new fit return object `FitResult`

### DIFF
--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -220,7 +220,7 @@ function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
     form = glm_formula(model, features)
     fitted_lm = GLM.lm(form, data; model.dropcollinear).model
     fitresult = FitResult(
-        GLM.coef(fitted_lm), GLM.dispersion(fitted_lm), (feature_names = features,)
+        GLM.coef(fitted_lm), GLM.dispersion(fitted_lm), (features = features,)
     )
 
     # form the report
@@ -238,7 +238,7 @@ function MMI.fit(model::LinearCountRegressor, verbosity::Int, X, y)
     form = glm_formula(model, features)
     fitted_glm = GLM.glm(form, data, model.distribution, model.link; offset).model
     fitresult = FitResult(
-        GLM.coef(fitted_glm), GLM.dispersion(fitted_glm), (feature_names = features,)
+        GLM.coef(fitted_glm), GLM.dispersion(fitted_glm), (features = features,)
     )
     # form the report
     report = glm_report(fitted_glm, features)
@@ -257,7 +257,7 @@ function MMI.fit(model::LinearBinaryClassifier, verbosity::Int, X, y)
     form = glm_formula(model, features)
     fitted_glm = GLM.glm(form, data, Distributions.Bernoulli(), model.link; offset).model
     fitresult = FitResult(
-        GLM.coef(fitted_glm), GLM.dispersion(fitted_glm), (feature_names = features,)
+        GLM.coef(fitted_glm), GLM.dispersion(fitted_glm), (features = features,)
     )
     # form the report
     report = glm_report(fitted_glm, features)
@@ -273,7 +273,7 @@ glm_fitresult(::LinearBinaryClassifier, fitresult) = fitresult[1]
 function MMI.fitted_params(model::GLM_MODELS, fitresult)
     result = glm_fitresult(model, fitresult)
     coef = coefs(result)
-    feature_names = copy(params(result).feature_names)
+    features = copy(params(result).features)
     if model.fit_intercept
         intercept = coef[end]
         coef_ = coef[1:end-1]
@@ -281,7 +281,7 @@ function MMI.fitted_params(model::GLM_MODELS, fitresult)
         intercept = zero(eltype(coef))
         coef_ = copy(coef)
     end
-    return (; feature_names, coef=coef_, intercept)
+    return (; features, coef=coef_, intercept)
 end
 
 

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -205,17 +205,6 @@ struct FitResult{V<:AbstractVector, T, R}
     dispersion::T
     "Other fitted parameters specific to a fitted model"
     params::R
-    function FitResult(
-        coefs::AbstractVector,
-        dispersion,
-        params
-    )
-        return new{
-            typeof(coefs),
-            typeof(dispersion),
-            typeof(params)
-        }(coefs, dispersion, params)
-    end
 end
 
 coefs(fr::FitResult) = fr.coefs

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -145,12 +145,7 @@ function glm_report(glm_model, features)
             (string(features[i]) for i in eachindex(features))...; "(Intercept)"
         ]
     end
-    return (;
-        deviance=deviance,
-        dof_residual=dof_residual,
-        stderror=stderror, vcov=vcov,
-        coef_table=coef_table
-    )
+    return (; deviance, dof_residual, stderror, vcov, coef_table)
 end
 
 

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -292,7 +292,7 @@ function MMI.fitted_params(model::GLM_MODELS, fitresult)
         intercept = zero(eltype(coef))
         coef_ = copy(coef)
     end
-    return (; feature_names=feature_names, coef=coef_, intercept=intercept)
+    return (; feature_names, coef=coef_, intercept)
 end
 
 

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -190,8 +190,8 @@ function glm_features(model, X)
         first_row = iterate(Tables.rows(X), 1)[1]
         table_features = first_row === nothing ? Symbol[] : _to_array(keys(first_row))
     end
-    features = filter!(x -> x != model.offsetcol, table_features)
-    return features
+    filter!(!=(model.offsetcol), table_features)
+    return table_features
 end
 
 ####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -202,7 +202,7 @@ end
     @test mean(cross_entropy(yhat, y)) < 0.6
 
     fp = fitted_params(lr, fitresult)
-    @test fp.feature_names == [:a, :b, :c]
+    @test fp.features == [:a, :b, :c]
     @test :intercept in keys(fp)
     @test intercept == fp.intercept
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,9 +54,8 @@ model = atom_ols
 
 p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
-@test p_distr[1] == Distributions.Normal(
-    p[1], MLJGLMInterface.dispersion(fitresult)
-)
+dispersion =  MLJGLMInterface.dispersion(fitresult)
+@test p_distr[1] == Distributions.Normal(p[1], dispersion)
 
 ###
 ### Logistic regression

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,9 @@ model = atom_ols
 
 p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
-@test p_distr[1] == Distributions.Normal(p[1], GLM.dispersion(fitresult.model))
+@test p_distr[1] == Distributions.Normal(
+    p[1], MLJGLMInterface.dispersion(fitresult)
+)
 
 ###
 ### Logistic regression
@@ -158,7 +160,7 @@ end
         fp = fitted_params(lr, fitresult)
 
         @test fp.coef ≈ [2, -1] atol=0.03
-        @test fp.intercept === nothing
+        @test iszero(fp.intercept)
     end
     @testset "Test Linear regression with offset" begin
         N = 1000

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,8 +194,8 @@ end
     X = (a=[1, 9, 4, 2], b=[1, 2, 1, 4], c=[9, 1, 5, 3])
     y = categorical([true, true, false, false])
     lr = LinearBinaryClassifier(fit_intercept=true)
-    fitresult, _, _ = fit(lr, 1, X, y)
-    ctable = coeftable(first(fitresult))
+    fitresult, _, report = fit(lr, 1, X, y)
+    ctable = last(report)
     parameters = ctable.rownms # Row names.
     @test parameters == ["a", "b", "c", "(Intercept)"]
     intercept = ctable.cols[1][4]
@@ -203,7 +203,7 @@ end
     @test mean(cross_entropy(yhat, y)) < 0.6
 
     fp = fitted_params(lr, fitresult)
-    @test fp.features == ["a", "b", "c"]
+    @test fp.feature_names == [:a, :b, :c]
     @test :intercept in keys(fp)
     @test intercept == fp.intercept
 end


### PR DESCRIPTION
This PR Introduces a new fit return object `FitResult`, which houses the glm model coefficients (including intercept), dispersion parameter of the glm distribution, and any other fit result that may be specific to a given glm model. This has the advantage that it no longer houses the fit data, hence allowing serialization of only the key components of a model. 
In addition this PR also adds a new parameter `coef_table` to the glm report.

```julia
julia> X = (; a=[1, 9, 4, 2], b=[1, 2, 1, 4], c=[9, 1, 5, 3]);

julia> y = categorical([true, true, false, false]);

julia> lr = LinearBinaryClassifier(fit_intercept=true);

julia> fitresult, _, report = fit(lr, 1, X, y);

julia> last(report)
─────────────────────────────────────────────────────────────────────────
                 Coef.  Std. Error      z  Pr(>|z|)  Lower 95%  Upper 95%
─────────────────────────────────────────────────────────────────────────
a              19.1818     1525.99   0.01    0.9900   -2971.7     3010.07
b              27.9007     2951.02   0.01    0.9925   -5755.98    5811.79
c              22.6694     1902.78   0.01    0.9905   -3706.71    3752.05
(Intercept)  -234.541     20231.5   -0.01    0.9908  -39887.6    39418.6
─────────────────────────────────────────────────────────────────────────

julia> fitresult[1]
MLJGLMInterface.FitResult{Vector{Float64}, Float64, NamedTuple{(:feature_names,), Tuple{Vector{Symbol}}}}([19.18176343654053, 27.900746816786167, 22.669356788638794, -234.54065292860898], 1.0, (feature_names = [:a, :b, :c],))
```
(for comparison, see https://github.com/JuliaAI/MLJGLMInterface.jl/pull/12.)

closes #16 

cc. @ablaom , @rikhuijzer 
