### PR TITLE
allow `report` customization with `report_keys` kwarg.

### DIFF
--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -163,9 +163,7 @@ function glm_report(glm_model, features, reportkeys)
             # This means `fit_intercept` is false
             coef_table.rownms = string.(features)
         else      
-            coef_table.rownms = [
-                (string(features[i]) for i in eachindex(features))...; "(Intercept)"
-            ]
+            coef_table.rownms = [string.(features); "(Intercept)"]
         end
         report_dict[:coef_table] = coef_table
     end

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -45,17 +45,22 @@ const LCR_DESCR = "Linear count regressor with specified "*
 # LinearBinaryClassifier --> Probabilistic w Binary target // logit,cauchit,..
 # MulticlassClassifier   --> Probabilistic w Multiclass target
 
+const VALID_KEYS = [:deviance, :dof_residual, :stderror, :vcov, :coef_table]
+const DEFAULT_KEYS = VALID_KEYS # For more understandable warning mssg by `@mlj_model`.
+const KEYS_TYPE = Union{Nothing, AbstractVector{Symbol}}
 
 @mlj_model mutable struct LinearRegressor <: MMI.Probabilistic
     fit_intercept::Bool = true
     dropcollinear::Bool = false
     offsetcol::Union{Symbol, Nothing} = nothing
+    report_keys::KEYS_TYPE = DEFAULT_KEYS::(isnothing(_) || issubset(_, VALID_KEYS))
 end
 
 @mlj_model mutable struct LinearBinaryClassifier <: MMI.Probabilistic
     fit_intercept::Bool = true
     link::GLM.Link01 = GLM.LogitLink()
     offsetcol::Union{Symbol, Nothing} = nothing
+    report_keys::KEYS_TYPE = DEFAULT_KEYS::(isnothing(_) || issubset(_, VALID_KEYS))
 end
 
 @mlj_model mutable struct LinearCountRegressor <: MMI.Probabilistic
@@ -63,6 +68,7 @@ end
     distribution::Distributions.Distribution = Distributions.Poisson()
     link::GLM.Link = GLM.LogLink()
     offsetcol::Union{Symbol, Nothing} = nothing
+    report_keys::KEYS_TYPE = DEFAULT_KEYS::(isnothing(_) || issubset(_, VALID_KEYS))
 end
 
 # Short names for convenience here
@@ -125,27 +131,45 @@ function prepare_inputs(model, X; handle_intercept=false)
 end
 
 """
-    glm_report(glm_model, features)
+    glm_report(glm_model, features, reportkeys)
 
-Report based on the fitted `LinearModel/GeneralizedLinearModel`, `glm_model`.
+Report based on a fitted `LinearModel/GeneralizedLinearModel`, `glm_model` 
+and keyed on `reportkeys`.
 """
-function glm_report(glm_model, features)
-    deviance = GLM.deviance(glm_model)
-    dof_residual = GLM.dof_residual(glm_model)
-    stderror = GLM.stderror(glm_model)
-    vcov = GLM.vcov(glm_model)
-    coef_table = GLM.coeftable(glm_model)
-    # Update the variable names in the `coef_table` with the actual variable
-    # names seen during fit.
-    if length(coef_table.rownms) == length(features)
-        # This means `fit_intercept` is false
-        coef_table.rownms = string.(features)
-    else      
-        coef_table.rownms = [
-            (string(features[i]) for i in eachindex(features))...; "(Intercept)"
-        ]
+glm_report
+
+glm_report(glm_model, features, ::Nothing) = NamedTuple()
+
+function glm_report(glm_model, features, reportkeys)
+    isempty(reportkeys) && return NamedTuple()
+    report_dict = Dict{Symbol, Any}() 
+    if in(:deviance, reportkeys)
+        report_dict[:deviance] = GLM.deviance(glm_model)
     end
-    return (; deviance, dof_residual, stderror, vcov, coef_table)
+    if in(:dof_residual, reportkeys)
+        report_dict[:dof_residual] = GLM.dof_residual(glm_model)
+    end
+    if in(:stderror, reportkeys)
+        report_dict[:stderror] = GLM.stderror(glm_model)
+    end
+    if in(:vcov, reportkeys)
+        report_dict[:vcov] = GLM.vcov(glm_model)
+    end
+    if in(:coef_table, reportkeys)
+        coef_table = GLM.coeftable(glm_model)
+        # Update the variable names in the `coef_table` with the actual variable
+        # names seen during fit.
+        if length(coef_table.rownms) == length(features)
+            # This means `fit_intercept` is false
+            coef_table.rownms = string.(features)
+        else      
+            coef_table.rownms = [
+                (string(features[i]) for i in eachindex(features))...; "(Intercept)"
+            ]
+        end
+        report_dict[:coef_table] = coef_table
+    end
+    return NamedTuple{Tuple(keys(report_dict))}(values(report_dict))
 end
 
 
@@ -222,9 +246,8 @@ function MMI.fit(model::LinearRegressor, verbosity::Int, X, y)
     fitresult = FitResult(
         GLM.coef(fitted_lm), GLM.dispersion(fitted_lm), (features = features,)
     )
-
     # form the report
-    report = glm_report(fitted_lm, features)
+    report = glm_report(fitted_lm, features, model.report_keys)
     cache = nothing
     # return
     return fitresult, cache, report
@@ -241,7 +264,7 @@ function MMI.fit(model::LinearCountRegressor, verbosity::Int, X, y)
         GLM.coef(fitted_glm), GLM.dispersion(fitted_glm), (features = features,)
     )
     # form the report
-    report = glm_report(fitted_glm, features)
+    report = glm_report(fitted_glm, features, model.report_keys)
     cache = nothing
     # return
     return fitresult, cache, report
@@ -260,7 +283,7 @@ function MMI.fit(model::LinearBinaryClassifier, verbosity::Int, X, y)
         GLM.coef(fitted_glm), GLM.dispersion(fitted_glm), (features = features,)
     )
     # form the report
-    report = glm_report(fitted_glm, features)
+    report = glm_report(fitted_glm, features, model.report_keys)
     cache = nothing
     # return
     return (fitresult, decode), cache, report

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -162,7 +162,7 @@ function glm_report(glm_model, features, reportkeys)
         if length(coef_table.rownms) == length(features)
             # This means `fit_intercept` is false
             coef_table.rownms = string.(features)
-        else      
+        else
             coef_table.rownms = [string.(features); "(Intercept)"]
         end
         report_dict[:coef_table] = coef_table

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -155,7 +155,7 @@ function glm_report(glm_model, features, reportkeys)
     if in(:vcov, reportkeys)
         report_dict[:vcov] = GLM.vcov(glm_model)
     end
-    if in(:coef_table, reportkeys)
+    if :coef_table in reportkeys
         coef_table = GLM.coeftable(glm_model)
         # Update the variable names in the `coef_table` with the actual variable
         # names seen during fit.

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -152,7 +152,7 @@ function glm_report(glm_model, features, reportkeys)
     if in(:stderror, reportkeys)
         report_dict[:stderror] = GLM.stderror(glm_model)
     end
-    if in(:vcov, reportkeys)
+    if :vcov in reportkeys
         report_dict[:vcov] = GLM.vcov(glm_model)
     end
     if :coef_table in reportkeys

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,8 +49,12 @@ model = atom_ols
 @test is_supervised(model)
 @test package_license(model) == "MIT"
 @test prediction_type(model) == :probabilistic
-@test hyperparameters(model) == (:fit_intercept, :dropcollinear, :offsetcol)
-@test hyperparameter_types(model) == ("Bool", "Bool", "Union{Nothing, Symbol}")
+@test hyperparameters(model) == (:fit_intercept, :dropcollinear, :offsetcol, :report_keys)
+hyp_types = hyperparameter_types(model)
+@test hyp_types[1] == "Bool"
+@test hyp_types[2] == "Bool"
+@test hyp_types[3] == "Union{Nothing, Symbol}"
+@test hyp_types[4] == "Union{Nothing, AbstractVector{Symbol}}"
 
 p_distr = predict(atom_ols, fitresult, selectrows(X, test))
 
@@ -205,4 +209,29 @@ end
     @test fp.features == [:a, :b, :c]
     @test :intercept in keys(fp)
     @test intercept == fp.intercept
+end
+
+@testset "Param names in report" begin
+    X = (a=[1, 4, 3, 1], b=[2, 0, 1, 4], c=[7, 1, 7, 3])
+    y = categorical([true, false, true, false])
+    # check that by default all possible keys are added in the report
+    lr = LinearBinaryClassifier()
+    _, _, report = fit(lr, 1, X, y)
+    @test :deviance in keys(report) 
+    @test :dof_residual in keys(report)
+    @test :stderror in keys(report)
+    @test :vcov in keys(report)
+    @test :coef_table in keys(report)
+
+    # check that report is valid if only some keys are specified
+    lr = LinearBinaryClassifier(report_keys = [:stderror, :deviance])
+    _, _, report = fit(lr, 1, X, y)
+    @test :deviance in keys(report) 
+    @test :stderror in keys(report)
+
+    # check that an empty `NamedTuple` is outputed for
+    # `report_params === nothing`
+    lr = LinearBinaryClassifier(report_keys=nothing)
+    _, _, report = fit(lr, 1, X, y)
+    @test report === NamedTuple()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,7 @@ end
     _, _, report = fit(lr, 1, X, y)
     @test :deviance in keys(report) 
     @test :stderror in keys(report)
+@test :dof_residual ∉ keys(report)
 
     # check that an empty `NamedTuple` is outputed for
     # `report_params === nothing`


### PR DESCRIPTION
This PR allows the user to customize the `report`, gotten from fitting any model defined in this package. Report customization is controlled with `report_keys` model hyper-parameter. 
```julia
julia> X = (; a=[3, 1, 4, 2], b=[1, 2, 7, 4], c=[9, 1, 5, 3]);

julia> y = categorical([true, true, false, false]);

julia> lr_allreport = LinearBinaryClassifier();

julia> lr_noreport = LinearBinaryClassifier(report_keys = nothing);

julia> lr_coef_table_report = LinearBinaryClassifier(report_keys=[:coef_table]);

julia> _, _, allreport = fit(lr_allreport, 1, X, y);

julia> _, _, noreport = fit(lr_noreport, 1, X, y);

julia> _, _, coef_table_report = fit(lr_coef_table_report, 1, X, y);

julia> allreport
(stderror = [9133.978446428515, 3323.4927437106717, 2847.4450608477055, 3376.1106757114344],
 dof_residual = 1.0,
 vcov = [8.342956225982067e7 -2.996413855810473e7 -2.5733907232254583e7 1.2103161848960392e7; -2.996413855810473e7 1.1045604017497487e7 9.283007631726578e6 -5.522802008748977e6; -2.5733907232254583e7 9.283007631726578e6 8.107943374545994e6 -4.641503815863521e6; 1.2103161848960392e7 -5.522802008748977e6 -4.641503815863521e6 1.1398123294652719e7],
 deviance = 5.111376477155369e-7,
 coef_table = ────────────────────────────────────────────────────────────────────────
                Coef.  Std. Error      z  Pr(>|z|)  Lower 95%  Upper 95%
────────────────────────────────────────────────────────────────────────
a             61.5311     9133.98   0.01    0.9946  -17840.7    17963.8
b            -28.399      3323.49  -0.01    0.9932   -6542.33    6485.53
c            -18.9326     2847.45  -0.01    0.9947   -5599.82    5561.96
(Intercept)   30.7656     3376.11   0.01    0.9927   -6586.29    6647.82
────────────────────────────────────────────────────────────────────────,)

julia> isempty(noreport)
true

julia> coef_table_report.coef_table
────────────────────────────────────────────────────────────────────────
                Coef.  Std. Error      z  Pr(>|z|)  Lower 95%  Upper 95%
────────────────────────────────────────────────────────────────────────
a             61.5311     9133.98   0.01    0.9946  -17840.7    17963.8
b            -28.399      3323.49  -0.01    0.9932   -6542.33    6485.53
c            -18.9326     2847.45  -0.01    0.9947   -5599.82    5561.96
(Intercept)   30.7656     3376.11   0.01    0.9927   -6586.29    6647.82
────────────────────────────────────────────────────────────────────────

```

cc. @ablaom , @rikhuijzer 