### PR TITLE
add more parameters to control fitting, and add data checks

### DIFF
--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -107,7 +107,7 @@ _to_array(v) = collect(v)
 """
     split_X_offset(X, offsetcol::Nothing)
 
-When no offset is specied, return X, an empty vector.
+When no offset is specified, return `X` and an empty vector.
 """
 split_X_offset(X, offsetcol::Nothing) = (X, Float64[])
 
@@ -150,7 +150,6 @@ function _throw_sample_size_error(model, est_dispersion_param)
         distribution_info = "\b"
     end
 
-    ""
     throw(
         ArgumentError(
             " `$(modelname)` with `fit_intercept = $(model.fit_intercept)`,"*
@@ -160,10 +159,14 @@ function _throw_sample_size_error(model, est_dispersion_param)
     return nothing
 end
 
-# `_requires_info` returns one of the following strings
-# "`n_samples >= n_features`", "`n_samples > n_features`"
-# "`n_samples >= n_features - 1`",  "`n_samples > n_features - 1`"
-# "`n_samples >= n_features + 1`", "`n_samples > n_features + 1`"
+""" 
+    _requires_info(model, est_dispersion_param)
+    
+Returns one of the following strings
+- "`n_samples >= n_features`", "`n_samples > n_features`"
+- "`n_samples >= n_features - 1`",  "`n_samples > n_features - 1`"
+- "`n_samples >= n_features + 1`", "`n_samples > n_features + 1`"
+"""
 function _requires_info(model, est_dispersion_param)
     inequality = est_dispersion_param ? ">" : ">="
     int_num = model.fit_intercept - !isnothing(model.offsetcol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,11 +184,11 @@ end
 modeltypes = [LinearRegressor, LinearBinaryClassifier, LinearCountRegressor]
 @testset "Test prepare_inputs" begin
     @testset "check sample size" for fit_intercept in [true, false]
-        lin_reg = LinearRegressor(;fit_intercept)
+        lin_reg = LinearRegressor(; fit_intercept)
         X_lin_reg = MLJBase.table(rand(3, 3 + fit_intercept))
-        log_reg = LinearBinaryClassifier(;fit_intercept)
+        log_reg = LinearBinaryClassifier(; fit_intercept)
         X_log_reg = MLJBase.table(rand(2, 3 + fit_intercept))
-        lcr = LinearCountRegressor(;distribution=Poisson(), fit_intercept)
+        lcr = LinearCountRegressor(; distribution=Poisson(), fit_intercept)
         X_lcr = X_log_reg
         for (m, X) in [(lin_reg, X_lin_reg), (log_reg, X_log_reg), (lcr, X_lcr)]
             @test_throws ArgumentError MLJGLMInterface.prepare_inputs(m, X)


### PR DESCRIPTION
This PR add several checks on the dataset. One of such checks is to make sure that the dataset doesn't contain more features than observations (i.e the dataset isn't wide). This PR also throws an informative error message for some hidden errors due to flawed `offsetcol` logic. For example, users were previously allowed (maybe unintentionally) to choose an offset column that wasn't among the features of the training dataset, leading to confusing errors. 

cc. @ablaom , @rikhuijzer 