### PR TITLE
Explicitly add `StatsModels` dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,20 @@
 name = "MLJGLMInterface"
 uuid = "caf8df21-4939-456d-ac9c-5fefbfb04c0c"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
+StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Distributions = "0.23, 0.24, 0.25"
 GLM = "1.4"
 MLJModelInterface = "1.4"
+StatsModels = "0.6, 0.7"
 Tables = "1.1"
 julia = "1.6"
 


### PR DESCRIPTION
Improves #35 by explicitly adding `StatsModels` and setting a compat entry. Thanks to @kleinschmidt for the suggestion.

I have still kept the argument flipping workaround. The costs appear quite minimal in terms of code complexity and computational costs, while the benefits are that its less likely that `MLJGLMInterface` will suddenly break again in the future.