### PR TITLE
Expose raw fitted GLM model in report

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,8 +22,9 @@ julia = "1.6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+StatisticalMeasures = "a19d573c-0a75-4610-95b3-7071388c7541"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "MLJBase", "StableRNGs", "Statistics", "Test"]
+test = ["LinearAlgebra", "MLJBase", "StableRNGs", "StatisticalMeasures", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJGLMInterface"
 uuid = "caf8df21-4939-456d-ac9c-5fefbfb04c0c"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -51,10 +51,10 @@ const VALID_KEYS = [
     :stderror,
     :vcov,
     :coef_table,
-    :raw_glm_model,
+    :glm_model,
 ]
 const VALID_KEYS_LIST = join(map(k-> "`:$k`", VALID_KEYS), ", ", " and ")
-const DEFAULT_KEYS = setdiff(VALID_KEYS, [:raw_glm_model,])
+const DEFAULT_KEYS = setdiff(VALID_KEYS, [:glm_model,])
 const KEYS_TYPE = Union{Nothing, AbstractVector{Symbol}}
 
 @mlj_model mutable struct LinearRegressor <: MMI.Probabilistic
@@ -295,8 +295,8 @@ function glm_report(glm_model, features, reportkeys)
         end
         report_dict[:coef_table] = coef_table
     end
-    if :raw_glm_model in reportkeys
-        report_dict[:raw_glm_model] = glm_model
+    if :glm_model in reportkeys
+        report_dict[:glm_model] = glm_model
     end
 
     return NamedTuple{Tuple(keys(report_dict))}(values(report_dict))
@@ -602,7 +602,7 @@ Here
    An offset is a variable which is known to have a coefficient of 1.
 
 - `report_keys`: `Vector` of keys for the report. Possible keys are: $VALID_KEYS_LIST. By
-  default only `:raw_glm_model` is excluded.
+  default only `:glm_model` is excluded.
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -646,8 +646,8 @@ When all keys are enabled in `report_keys`, the following fields are available i
 - `coef_table`: Table which displays coefficients and summarizes their significance
   and confidence intervals.
 
-- `raw_glm_model`: The raw fitted model returned by `GLM.lm`. Note this points to training
-  data.
+- `glm_model`: The raw fitted model returned by `GLM.lm`. Note this points to training
+  data. Refer to the GLM.jl documentation for usage.
 
 # Examples
 
@@ -729,7 +729,7 @@ Train the machine using `fit!(mach, rows=...)`.
   the factor used to update the linear fit.
 
 - `report_keys`: `Vector` of keys for the report. Possible keys are: $VALID_KEYS_LIST. By
-  default only `:raw_glm_model` is excluded.
+  default only `:glm_model` is excluded.
 
 # Operations
 
@@ -765,8 +765,8 @@ The fields of `report(mach)` are:
 - `coef_table`: Table which displays coefficients and summarizes their significance and
   confidence intervals.
 
-- `raw_glm_model`: The raw fitted model returned by `GLM.glm`. Note this points to training
-  data.
+- `glm_model`: The raw fitted model returned by `GLM.lm`. Note this points to training
+  data. Refer to the GLM.jl documentation for usage.
 
 # Examples
 
@@ -861,7 +861,7 @@ Train the machine using `fit!(mach, rows=...)`.
   the factor used to update the linear fit.
 
 - `report_keys`: `Vector` of keys for the report. Possible keys are: $VALID_KEYS_LIST. By
-  default only `:raw_glm_model` is excluded.
+  default only `:glm_model` is excluded.
 
 # Operations
 
@@ -898,8 +898,8 @@ The fields of `report(mach)` are:
 - `coef_table`: Table which displays coefficients and summarizes their significance and
   confidence intervals.
 
-- `raw_glm_model`: The raw fitted model returned by `GLM.glm`. Note this points to training
-  data.
+- `glm_model`: The raw fitted model returned by `GLM.lm`. Note this points to training
+  data. Refer to the GLM.jl documentation for usage.
 
 
 # Examples

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -45,7 +45,15 @@ const LCR_DESCR = "Linear count regressor with specified "*
 # LinearBinaryClassifier --> Probabilistic w Binary target // logit,cauchit,..
 # MulticlassClassifier   --> Probabilistic w Multiclass target
 
-const VALID_KEYS = [:deviance, :dof_residual, :stderror, :vcov, :coef_table]
+const VALID_KEYS = [
+    :deviance,
+    :dof_residual,
+    :stderror,
+    :vcov,
+    :coef_table,
+    :raw_glm_model,
+]
+const VALID_KEYS_LIST = join(map(k-> ":$k", VALID_KEYS), ", ", " and ")
 const DEFAULT_KEYS = VALID_KEYS # For more understandable warning mssg by `@mlj_model`.
 const KEYS_TYPE = Union{Nothing, AbstractVector{Symbol}}
 
@@ -287,6 +295,10 @@ function glm_report(glm_model, features, reportkeys)
         end
         report_dict[:coef_table] = coef_table
     end
+    if :raw_glm_model in reportkeys
+        report_dict[:raw_glm_model] = glm_model
+    end
+
     return NamedTuple{Tuple(keys(report_dict))}(values(report_dict))
 end
 
@@ -590,8 +602,7 @@ Here
    An offset is a variable which is known to have a coefficient of 1.
 
 - `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: vector of keys to be used in
-  the report. Should be one of: `:deviance`, `:dof_residual`, `:stderror`, `:vcov`,
-  `:coef_table`.
+  the report. Possible keys are: $VALID_KEYS_LIST.
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -619,7 +630,8 @@ The fields of `fitted_params(mach)` are:
 
 # Report
 
-When all keys are enabled in `report_keys`, the following fields are available in `report(mach)`:
+When all keys are enabled in `report_keys`, the following fields are available in
+`report(mach)`:
 
 - `deviance`: Measure of deviance of fitted model with respect to
   a perfectly fitted model. For a linear model, this is the weighted
@@ -633,6 +645,9 @@ When all keys are enabled in `report_keys`, the following fields are available i
 
 - `coef_table`: Table which displays coefficients and summarizes their significance
   and confidence intervals.
+
+- `raw_glm_model`: The raw fitted model returned by `GLM.lm`. Note this points to training
+  data.
 
 # Examples
 
@@ -713,8 +728,8 @@ Train the machine using `fit!(mach, rows=...)`.
 - `minstepfac::Real=0.001`: Minimum step fraction. Must be between 0 and 1. Lower bound for
   the factor used to update the linear fit.
 
-- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: keys to be used in the report. Should
-  be one of: `:deviance`, `:dof_residual`, `:stderror`, `:vcov`, `:coef_table`.
+- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: keys to be used in the
+  report. Possible keys are: $VALID_KEYS_LIST.
 
 # Operations
 
@@ -749,6 +764,9 @@ The fields of `report(mach)` are:
 
 - `coef_table`: Table which displays coefficients and summarizes their significance and
   confidence intervals.
+
+- `raw_glm_model`: The raw fitted model returned by `GLM.glm`. Note this points to training
+  data.
 
 # Examples
 
@@ -842,8 +860,8 @@ Train the machine using `fit!(mach, rows=...)`.
 - `minstepfac::Real=0.001`: Minimum step fraction. Must be between 0 and 1. Lower bound for
   the factor used to update the linear fit.
 
-- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: keys to be used in the report. Should
-  be one of: `:deviance`, `:dof_residual`, `:stderror`, `:vcov`, `:coef_table`.
+- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: keys to be used in the
+  report. Possible keys are: $VALID_KEYS_LIST.
 
 # Operations
 
@@ -879,6 +897,9 @@ The fields of `report(mach)` are:
 
 - `coef_table`: Table which displays coefficients and summarizes their significance and
   confidence intervals.
+
+- `raw_glm_model`: The raw fitted model returned by `GLM.glm`. Note this points to training
+  data.
 
 
 # Examples

--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -53,8 +53,8 @@ const VALID_KEYS = [
     :coef_table,
     :raw_glm_model,
 ]
-const VALID_KEYS_LIST = join(map(k-> ":$k", VALID_KEYS), ", ", " and ")
-const DEFAULT_KEYS = VALID_KEYS # For more understandable warning mssg by `@mlj_model`.
+const VALID_KEYS_LIST = join(map(k-> "`:$k`", VALID_KEYS), ", ", " and ")
+const DEFAULT_KEYS = setdiff(VALID_KEYS, [:raw_glm_model,])
 const KEYS_TYPE = Union{Nothing, AbstractVector{Symbol}}
 
 @mlj_model mutable struct LinearRegressor <: MMI.Probabilistic
@@ -601,8 +601,8 @@ Here
 - `offsetcol=nothing`: Name of the column to be used as an offset, if any.
    An offset is a variable which is known to have a coefficient of 1.
 
-- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: vector of keys to be used in
-  the report. Possible keys are: $VALID_KEYS_LIST.
+- `report_keys`: `Vector` of keys for the report. Possible keys are: $VALID_KEYS_LIST. By
+  default only `:raw_glm_model` is excluded.
 
 Train the machine using `fit!(mach, rows=...)`.
 
@@ -728,8 +728,8 @@ Train the machine using `fit!(mach, rows=...)`.
 - `minstepfac::Real=0.001`: Minimum step fraction. Must be between 0 and 1. Lower bound for
   the factor used to update the linear fit.
 
-- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: keys to be used in the
-  report. Possible keys are: $VALID_KEYS_LIST.
+- `report_keys`: `Vector` of keys for the report. Possible keys are: $VALID_KEYS_LIST. By
+  default only `:raw_glm_model` is excluded.
 
 # Operations
 
@@ -860,8 +860,8 @@ Train the machine using `fit!(mach, rows=...)`.
 - `minstepfac::Real=0.001`: Minimum step fraction. Must be between 0 and 1. Lower bound for
   the factor used to update the linear fit.
 
-- `report_keys::Union{Symbol, Nothing}=DEFAULT_KEYS`: keys to be used in the
-  report. Possible keys are: $VALID_KEYS_LIST.
+- `report_keys`: `Vector` of keys for the report. Possible keys are: $VALID_KEYS_LIST. By
+  default only `:raw_glm_model` is excluded.
 
 # Operations
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,7 +325,8 @@ end
 @testset "Param names in report" begin
     X = (a=[1, 4, 3, 1], b=[2, 0, 1, 4], c=[7, 1, 7, 3])
     y = categorical([true, false, true, false])
-    # check that by default all possible keys are added in the report
+    # check that by default all possible keys are added in the report,
+    # except raw_glm_model:
     lr = LinearBinaryClassifier()
     _, _, report = fit(lr, 1, X, y)
     @test :deviance in keys(report)
@@ -333,17 +334,16 @@ end
     @test :stderror in keys(report)
     @test :vcov in keys(report)
     @test :coef_table in keys(report)
-    @test :raw_glm_model in keys(report)
-
-    @test report.raw_glm_model isa GLM.GeneralizedLinearModel
+    @test :raw_glm_model ∉ keys(report)
 
     # check that report is valid if only some keys are specified
-    lr = LinearBinaryClassifier(report_keys = [:stderror, :deviance])
+    lr = LinearBinaryClassifier(report_keys = [:stderror, :raw_glm_model])
     _, _, report = fit(lr, 1, X, y)
-    @test :deviance in keys(report)
+    @test :deviance ∉ keys(report)
     @test :stderror in keys(report)
-    @test :dof_residua ∉ keys(report)
-    @test :raw_glm_model ∉ keys(report)
+    @test :dof_residual ∉ keys(report)
+    @test :raw_glm_model in keys(report)
+    @test report.raw_glm_model isa GLM.GeneralizedLinearModel
 
     # check that an empty `NamedTuple` is outputed for
     # `report_params === nothing`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,7 +326,7 @@ end
     X = (a=[1, 4, 3, 1], b=[2, 0, 1, 4], c=[7, 1, 7, 3])
     y = categorical([true, false, true, false])
     # check that by default all possible keys are added in the report,
-    # except raw_glm_model:
+    # except glm_model:
     lr = LinearBinaryClassifier()
     _, _, report = fit(lr, 1, X, y)
     @test :deviance in keys(report)
@@ -334,16 +334,16 @@ end
     @test :stderror in keys(report)
     @test :vcov in keys(report)
     @test :coef_table in keys(report)
-    @test :raw_glm_model ∉ keys(report)
+    @test :glm_model ∉ keys(report)
 
     # check that report is valid if only some keys are specified
-    lr = LinearBinaryClassifier(report_keys = [:stderror, :raw_glm_model])
+    lr = LinearBinaryClassifier(report_keys = [:stderror, :glm_model])
     _, _, report = fit(lr, 1, X, y)
     @test :deviance ∉ keys(report)
     @test :stderror in keys(report)
     @test :dof_residual ∉ keys(report)
-    @test :raw_glm_model in keys(report)
-    @test report.raw_glm_model isa GLM.GeneralizedLinearModel
+    @test :glm_model in keys(report)
+    @test report.glm_model isa GLM.GeneralizedLinearModel
 
     # check that an empty `NamedTuple` is outputed for
     # `report_params === nothing`


### PR DESCRIPTION
Addresses: https://github.com/JuliaAI/MLJGLMInterface.jl/issues/40

This PR add `:raw_glm_model` to the list of user-specifiable report items (controlled by the `report_keys` hyperparameter. 

The default keys now includes the new `:raw_glm_model` key (and all other keys, as presently the case). This means that, by default, the report points to the training data, because raw GLM models do so. I'd suggest we tag this change as breaking for this reason, although technically, adding a keys, doesn't break the API.

