### PR TITLE
Retain data in tabular form

### DIFF
--- a/src/MLJGLMInterface.jl
+++ b/src/MLJGLMInterface.jl
@@ -274,16 +274,6 @@ function glm_formula(model, features::AbstractVector{Symbol})::FormulaTerm
 end
 
 """
-    glm_data(model, Xmatrix, y, features)
-
-Return data which is ready to be passed to `fit(form, data, ...)`.
-"""
-function glm_data(model, Xmatrix, y, features)
-    data = Tables.table([Xmatrix y]; header=[features...; :y])
-    return data
-end
-
-"""
     check_weights(w, y)
 
 Validate observation weights to be used in fitting `Linear/GeneralizedLinearModel` based

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,8 +294,8 @@ end
     fitresult, _, report = fit(lr, 1, X, y)
     ctable = last(report)
     parameters = ctable.rownms # Row names.
-    @test parameters == ["a", "b", "c", "(Intercept)"]
-    intercept = ctable.cols[1][4]
+    @test parameters == ["(Intercept)", "a", "b", "c"]
+    intercept = ctable.cols[1][1]
     yhat = predict(lr, fitresult, X)
     @test cross_entropy(yhat, y) < 0.6
 
@@ -359,8 +359,3 @@ end
     fit(lr, 1, X, y)
 end
 
-@testset "Issue 34" begin
-    model = LinearRegressor()
-    form = MLJGLMInterface.glm_formula(model, [:a, :b]) |> string
-    @test form == "y ~ a + b + 1"
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,12 +229,17 @@ end
 
 @testset "Test offsetting models" begin
     @testset "Test split_X_offset" begin
-        rng = StableRNGs.StableRNG(123)
-        N = 100
         X = (x1=[1,2,3], x2=[4,5,6])
         @test MLJGLMInterface.split_X_offset(X, nothing) == (X, Float64[])
         @test MLJGLMInterface.split_X_offset(X, :x1) == ((x2=[4,5,6],), [1,2,3])
 
+        lr = LinearRegressor(fit_intercept = false, offsetcol = :x1)
+        fitresult, _, report = fit(lr, 1, X, [5, 7, 9])
+        yhat = predict_mean(lr, fitresult, (x1 = [2, 3, 4], x2 = [5, 6, 7]))
+        @test yhat == [7.0, 9.0, 11.0]
+
+        rng = StableRNGs.StableRNG(123)
+        N = 100
         X = MLJBase.table(rand(rng, N, 3))
         Xnew, offset = MLJGLMInterface.split_X_offset(X, :x2)
         @test offset isa Vector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ expit(X) = 1 ./ (1 .+ exp.(-X))
 
     # test `predict` object
     p_distr = predict(atom_ols, fitresult, selectrows(X, test))
-    dispersion =  GLM.dispersion(fitresult.model)
+    dispersion =  MLJGLMInterface.dispersion(fitresult)
     @test p_distr[1] == Normal(p[1], dispersion)
 
     # test metadata
@@ -344,7 +344,7 @@ end
 
     fp = fitted_params(mach)
 
-    @test fp.features == Symbol.(["x1", "x2: 0", "x2: 1"])
+    @test fp.features == [:x1, :x2]
     @test_throws KeyError predict(mach, (x1 = [2,3,4], x2 = categorical([0,1,2])))
     @test all(isapprox.(pdf.(predict(mach, X), true), [0,0,1], atol = 1e-3))
 end


### PR DESCRIPTION
I rewrote some parts of this package in order to interface with GLM.jl more directly. Hopefully, this will make sure all the functionality GLM.jl has will also be available through MLJ. 

This pull solves both https://github.com/JuliaAI/MLJGLMInterface.jl/issues/44 and https://github.com/JuliaAI/MLJGLMInterface.jl/issues/42.

I removed `_matrix_and_features` as this is where the variable types (`CategoricalVector`) was lost. 

In order to predict with categorical values properly, we need the entire object returned by `GLM.glm`, as this contains information about classes. For now, I simply removed the `FitResult` and return the `TableRegressionModel` returned by `GLM.glm` instead (we can revert this if it is problematic, and find some other solution). I also changed `predict`, so we call `GLM.predict`, rather than constructing the model matrix in this package. `GLM.predict` calls `StatsModels.modelcols`, which does the dummy-encoding for categorical variables.

